### PR TITLE
Implement persistent SQLite storage for activities and registrations

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,13 +6,14 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Persistent SQLite storage for activities, students, and registrations
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
@@ -34,9 +35,9 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 ## Data Model
 
-The application uses a simple data model with meaningful identifiers:
+The application uses SQLite with a simple relational data model:
 
-1. **Activities** - Uses activity name as identifier:
+1. **Activities** - Uses activity name as unique identifier:
 
    - Description
    - Schedule
@@ -44,7 +45,20 @@ The application uses a simple data model with meaningful identifiers:
    - List of student emails who are signed up
 
 2. **Students** - Uses email as identifier:
-   - Name
-   - Grade level
+   - Email
 
-All data is stored in memory, which means data will be reset when the server restarts.
+3. **Registrations** - Links students to activities:
+   - Activity reference
+   - Student reference
+   - Registration timestamp
+
+Data is stored in `src/school.db` and survives server restarts.
+
+## Database setup and migration
+
+- On app startup, tables are created automatically if they do not exist.
+- On first run (empty database), default activities and participant registrations are seeded.
+- Existing API behavior remains compatible for:
+  - `GET /activities`
+  - `POST /activities/{activity_name}/signup?email=...`
+  - `DELETE /activities/{activity_name}/unregister?email=...`

--- a/src/app.py
+++ b/src/app.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import sqlite3
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -19,8 +20,9 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+DB_PATH = current_dir / "school.db"
+
+DEFAULT_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -78,6 +80,72 @@ activities = {
 }
 
 
+def get_db_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def init_db():
+    with get_db_connection() as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS activities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS students (
+                email TEXT PRIMARY KEY
+            );
+
+            CREATE TABLE IF NOT EXISTS registrations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                activity_id INTEGER NOT NULL,
+                student_email TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(activity_id, student_email),
+                FOREIGN KEY(activity_id) REFERENCES activities(id) ON DELETE CASCADE,
+                FOREIGN KEY(student_email) REFERENCES students(email) ON DELETE CASCADE
+            );
+            """
+        )
+
+        count_row = conn.execute("SELECT COUNT(*) AS count FROM activities").fetchone()
+        if count_row["count"] == 0:
+            for name, details in DEFAULT_ACTIVITIES.items():
+                cursor = conn.execute(
+                    """
+                    INSERT INTO activities (name, description, schedule, max_participants)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (name, details["description"], details["schedule"], details["max_participants"])
+                )
+                activity_id = cursor.lastrowid
+
+                for email in details["participants"]:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO students (email) VALUES (?)",
+                        (email,)
+                    )
+                    conn.execute(
+                        """
+                        INSERT INTO registrations (activity_id, student_email)
+                        VALUES (?, ?)
+                        """,
+                        (activity_id, email)
+                    )
+
+
+@app.on_event("startup")
+def startup_event():
+    init_db()
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -85,48 +153,109 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    with get_db_connection() as conn:
+        activity_rows = conn.execute(
+            """
+            SELECT id, name, description, schedule, max_participants
+            FROM activities
+            ORDER BY name
+            """
+        ).fetchall()
+
+        registration_rows = conn.execute(
+            """
+            SELECT r.activity_id, r.student_email
+            FROM registrations r
+            JOIN activities a ON a.id = r.activity_id
+            ORDER BY a.name, r.student_email
+            """
+        ).fetchall()
+
+    participants_by_activity = {}
+    for row in registration_rows:
+        participants_by_activity.setdefault(row["activity_id"], []).append(row["student_email"])
+
+    response = {}
+    for row in activity_rows:
+        response[row["name"]] = {
+            "description": row["description"],
+            "schedule": row["schedule"],
+            "max_participants": row["max_participants"],
+            "participants": participants_by_activity.get(row["id"], [])
+        }
+
+    return response
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_db_connection() as conn:
+        activity_row = conn.execute(
+            "SELECT id FROM activities WHERE name = ?",
+            (activity_name,)
+        ).fetchone()
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        if activity_row is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
+        activity_id = activity_row["id"]
+        existing_registration = conn.execute(
+            """
+            SELECT 1 FROM registrations
+            WHERE activity_id = ? AND student_email = ?
+            """,
+            (activity_id, email)
+        ).fetchone()
+
+        if existing_registration is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is already signed up"
+            )
+
+        conn.execute(
+            "INSERT OR IGNORE INTO students (email) VALUES (?)",
+            (email,)
+        )
+        conn.execute(
+            "INSERT INTO registrations (activity_id, student_email) VALUES (?, ?)",
+            (activity_id, email)
         )
 
-    # Add student
-    activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_db_connection() as conn:
+        activity_row = conn.execute(
+            "SELECT id FROM activities WHERE name = ?",
+            (activity_name,)
+        ).fetchone()
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        if activity_row is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        activity_id = activity_row["id"]
+        existing_registration = conn.execute(
+            """
+            SELECT 1 FROM registrations
+            WHERE activity_id = ? AND student_email = ?
+            """,
+            (activity_id, email)
+        ).fetchone()
+
+        if existing_registration is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity"
+            )
+
+        conn.execute(
+            "DELETE FROM registrations WHERE activity_id = ? AND student_email = ?",
+            (activity_id, email)
         )
 
-    # Remove student
-    activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
## Summary
- replace in-memory activity state with persistent SQLite storage
- add startup database initialization for `activities`, `students`, and `registrations`
- seed default activities/registrations on first run only
- keep API contract compatible for `GET /activities`, signup, and unregister
- document database setup and persistence behavior in `src/README.md`

## Validation
- verified `GET /activities` returns expected structure
- verified duplicate signup protection (`400`)
- verified unregister behavior and missing-registration error path (`400`)
- verified data persists across server restart

Closes #9